### PR TITLE
Indicate inline double markers

### DIFF
--- a/packages/rehype-katex/index.js
+++ b/packages/rehype-katex/index.js
@@ -13,14 +13,21 @@ function parseMathHtml (html) {
     .parse(html)
 }
 
+function hasClass (element, className) {
+  return element.properties.className && element.properties.className.includes(className)
+}
+
+function isTag (element, tag) {
+  return element.tagName === tag
+}
+
 module.exports = function plugin (opts = {}) {
   if (opts.throwOnError == null) opts.throwOnError = false
   return function transform (node, file) {
     visit(node, 'element', function (element) {
-      const isInlineMath = element.tagName === 'span' &&
-        element.properties.className &&
-        element.properties.className.includes('inlineMath')
-      const isMath = element.tagName === 'div' && element.properties.className === 'math'
+      const isInlineMath = isTag(element, 'span') && hasClass(element, 'inlineMath')
+      const isMath = (opts.inlineDoubleDisplay && hasClass(element, 'inlineMathDouble')) ||
+        (isTag(element, 'div') && hasClass(element, 'math'))
 
       if (isInlineMath || isMath) {
         let renderedValue

--- a/packages/rehype-katex/index.js
+++ b/packages/rehype-katex/index.js
@@ -17,8 +17,11 @@ module.exports = function plugin (opts = {}) {
   if (opts.throwOnError == null) opts.throwOnError = false
   return function transform (node, file) {
     visit(node, 'element', function (element) {
-      const isInlineMath = element.tagName === 'span' && element.properties.className === 'inlineMath'
+      const isInlineMath = element.tagName === 'span' &&
+        element.properties.className &&
+        element.properties.className.includes('inlineMath')
       const isMath = element.tagName === 'div' && element.properties.className === 'math'
+
       if (isInlineMath || isMath) {
         let renderedValue
         try {
@@ -43,10 +46,7 @@ module.exports = function plugin (opts = {}) {
 
         const inlineMathAst = parseMathHtml(renderedValue).children[0]
 
-        Object.assign(element.properties, {className: isInlineMath
-          ? 'inlineMath'
-          : 'math'
-        })
+        Object.assign(element.properties, {className: element.properties.className})
         element.children = [inlineMathAst]
       }
     })

--- a/packages/remark-math/inline.js
+++ b/packages/remark-math/inline.js
@@ -8,7 +8,12 @@ const INLINE_MATH_DOUBLE = /^\$\$((?:\\\$|[^$])+)\$\$/
 
 module.exports = function inlinePlugin (opts = {}) {
   function inlineTokenizer (eat, value, silent) {
-    const match = INLINE_MATH_DOUBLE.exec(value) || INLINE_MATH.exec(value)
+    let isDouble = true
+    let match = INLINE_MATH_DOUBLE.exec(value)
+    if (!match) {
+      match = INLINE_MATH.exec(value)
+      isDouble = false
+    }
     const escaped = ESCAPED_INLINE_MATH.exec(value)
     if (escaped) {
       /* istanbul ignore if - never used (yet) */
@@ -35,7 +40,7 @@ module.exports = function inlinePlugin (opts = {}) {
         data: {
           hName: 'span',
           hProperties: {
-            className: 'inlineMath'
+            className: 'inlineMath' + (isDouble ? ' inlineMathDouble' : '')
           },
           hChildren: [
             {

--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,8 @@ const processor = remark()
   .use(remark2rehype)
   .use(katex, {
     throwOnError: false,
-    errorColor: '#FF0000'
+    errorColor: '#FF0000',
+    inlineDoubleDisplay: false
   })
   .use(stringify)
 
@@ -131,6 +132,14 @@ Throw if a KaTeX parse error occurs. (default: `false`)
 This is a same option of KaTeX. As long as `options.throwOnError` is not `true`, Malformed TeX will be colored by `options.errorColor`. (default: #cc0000)
 
 > [KaTeX#rendering-options](https://github.com/Khan/KaTeX#rendering-options)
+
+#### `options.inlineDoubleDisplay`
+
+Parses inline `$$` math as `inlineMath` but displays it like `\displaystyle` or `math` display mode. (default: `false`)
+
+This option, together with a CSS rule like `.inlineMathDouble {display: block; text-align: center;}` allows authors to have equations inside paragraphs on a separate line:
+
+![Example](https://cloud.githubusercontent.com/assets/2022803/24314687/26c96bb8-10e3-11e7-928e-f93cff49b456.png)
 
 ## Specs
 

--- a/specs/rehype-katex.spec.js
+++ b/specs/rehype-katex.spec.js
@@ -28,7 +28,8 @@ it('should parse into katex', () => {
     '$\\alpha$',
     '$$',
     '\\alpha\\beta',
-    '$$'
+    '$$',
+    'foo $$\\alpha$$ bar'
   ].join('\n')
 
   const result = processor.processSync(targetText).toString()
@@ -36,17 +37,66 @@ it('should parse into katex', () => {
 
   const expectedInlineMath = katex.renderToString('\\alpha')
 
-  expect(renderedAst.children[0].type).toEqual('element')
-  expect(renderedAst.children[0].tagName).toEqual('p')
-  expect(renderedAst.children[0].children[0].tagName).toEqual('span')
-  expect(renderedAst.children[0].children[0].properties.className).toEqual(expect.arrayContaining(['inlineMath']))
-  expect(toHtml(renderedAst.children[0].children[0].children[0], {fragment: true})).toEqual(expectedInlineMath)
+  const child1 = renderedAst.children[0]
+  expect(child1.type).toEqual('element')
+  expect(child1.tagName).toEqual('p')
+  expect(child1.children[0].tagName).toEqual('span')
+  expect(child1.children[0].properties.className).toEqual(expect.arrayContaining(['inlineMath']))
+  expect(toHtml(child1.children[0].children[0], {fragment: true})).toEqual(expectedInlineMath)
 
   const expectedMath = katex.renderToString('\\alpha\\beta', {displayMode: true})
 
-  expect(renderedAst.children[2].tagName).toEqual('div')
-  expect(renderedAst.children[2].properties.className).toEqual(expect.arrayContaining(['math']))
-  expect(toHtml(renderedAst.children[2].children[0], {fragment: true})).toEqual(expectedMath)
+  const child2 = renderedAst.children[2]
+  expect(child2.tagName).toEqual('div')
+  expect(child2.properties.className).toEqual(expect.arrayContaining(['math']))
+  expect(child2.children[0].children[0].properties.className).toEqual(expect.arrayContaining(['katex']))
+  expect(toHtml(child2.children[0], {fragment: true})).toEqual(expectedMath)
+
+  const child3 = renderedAst.children[4]
+  expect(child3.children[1].properties.className).toEqual(expect.arrayContaining(['inlineMath', 'inlineMathDouble']))
+  expect(child3.children[1].children[0].properties.className).toEqual(expect.arrayContaining(['katex']))
+})
+
+it('should put inlineDoubles in katex displaystyle', () => {
+  const processor = remark()
+    .use(math)
+    .use(remark2rehype)
+    .use(rehypeKatex, {
+      inlineDoubleDisplay: true
+    })
+    .use(stringify)
+
+  const targetText = [
+    '$\\alpha$',
+    '$$',
+    '\\alpha\\beta',
+    '$$',
+    'foo $$\\alpha$$ bar'
+  ].join('\n')
+
+  const result = processor.processSync(targetText).toString()
+  const renderedAst = parseHtml(result)
+
+  const expectedInlineMath = katex.renderToString('\\alpha')
+
+  const child1 = renderedAst.children[0]
+  expect(child1.type).toEqual('element')
+  expect(child1.tagName).toEqual('p')
+  expect(child1.children[0].tagName).toEqual('span')
+  expect(child1.children[0].properties.className).toEqual(expect.arrayContaining(['inlineMath']))
+  expect(toHtml(child1.children[0].children[0], {fragment: true})).toEqual(expectedInlineMath)
+
+  const expectedMath = katex.renderToString('\\alpha\\beta', {displayMode: true})
+
+  const child2 = renderedAst.children[2]
+  expect(child2.tagName).toEqual('div')
+  expect(child2.properties.className).toEqual(expect.arrayContaining(['math']))
+  expect(child2.children[0].children[0].properties.className).toEqual(expect.arrayContaining(['katex']))
+  expect(toHtml(child2.children[0], {fragment: true})).toEqual(expectedMath)
+
+  const child3 = renderedAst.children[4]
+  expect(child3.children[1].properties.className).toEqual(expect.arrayContaining(['inlineMath', 'inlineMathDouble']))
+  expect(child3.children[1].children[0].properties.className).toEqual(expect.arrayContaining(['katex-display']))
 })
 
 it('should handle error', () => {
@@ -68,11 +118,12 @@ it('should handle error', () => {
     errorColor: 'orange'
   })
 
-  expect(renderedAst.children[0].type).toEqual('element')
-  expect(renderedAst.children[0].tagName).toEqual('p')
-  expect(renderedAst.children[0].children[0].tagName).toEqual('span')
-  expect(renderedAst.children[0].children[0].properties.className).toEqual(expect.arrayContaining(['inlineMath']))
-  expect(toHtml(renderedAst.children[0].children[0].children[0], {fragment: true})).toEqual(expectedInlineMath)
+  const child1 = renderedAst.children[0]
+  expect(child1.type).toEqual('element')
+  expect(child1.tagName).toEqual('p')
+  expect(child1.children[0].tagName).toEqual('span')
+  expect(child1.children[0].properties.className).toEqual(expect.arrayContaining(['inlineMath']))
+  expect(toHtml(child1.children[0].children[0], {fragment: true})).toEqual(expectedInlineMath)
 
   expect(result.messages[0].message).toEqual('KaTeX parse error: Expected \'EOF\', got \'\\alpa\' at position 1: \\̲a̲l̲p̲a̲')
 })


### PR DESCRIPTION
Implements suggestion discussed here: https://github.com/Rokt33r/remark-math/issues/8

* It has tests.
* It refactors some conditions to make them shorter and make the code more readable.
* It adds an extra `inlineMathDouble` class to inline `$$`, so instead of `class="inlineMath"` the become `class="inlineMath inlineMathDouble"` to make it possible to style them differently.
* It adds a configurable option making the `inlineMathDouble` behave like `$\displaystyle`, which is how block `$$` are displayed. Option defaults to false.
* It adds documentation about this new option, with a screenshot showcasing something some users might desire.

Most importantly, it doesn't modify the current default behaviour, so absolutely no breaking change for current users.

<!--<img width="1311" alt="screen shot 2017-03-24 at 22 41 50" src="https://cloud.githubusercontent.com/assets/2022803/24314687/26c96bb8-10e3-11e7-928e-f93cff49b456.png">-->