### PR TITLE
Pass macros option to Katex

### DIFF
--- a/packages/rehype-katex/index.js
+++ b/packages/rehype-katex/index.js
@@ -24,6 +24,7 @@ function isTag (element, tag) {
 module.exports = function plugin (opts = {}) {
   if (opts.throwOnError == null) opts.throwOnError = false
   if (opts.errorColor == null) opts.errorColor = '#cc0000'
+  if (opts.macros == null) opts.macros = {}
   return function transform (node, file) {
     visit(node, 'element', function (element) {
       const isInlineMath = isTag(element, 'span') && hasClass(element, 'inlineMath')
@@ -33,7 +34,8 @@ module.exports = function plugin (opts = {}) {
         let renderedValue
         try {
           renderedValue = katex.renderToString(element.children[0].value, {
-            displayMode: isMath
+            displayMode: isMath,
+            macros: opts.macros
           })
         } catch (err) {
           if (opts.throwOnError) {
@@ -46,6 +48,7 @@ module.exports = function plugin (opts = {}) {
             try {
               renderedValue = katex.renderToString(element.children[0].value, {
                 displayMode: isMath,
+                macros: opts.macros,
                 throwOnError: false,
                 errorColor: opts.errorColor
               })

--- a/specs/rehype-katex.spec.js
+++ b/specs/rehype-katex.spec.js
@@ -99,6 +99,35 @@ it('should put inlineDoubles in katex displaystyle', () => {
     ]))
 })
 
+it('should take macros', () => {
+  const macros = {
+    '\\RR': '\\mathbb{R}'
+  }
+
+  const processor = remark()
+    .use(math)
+    .use(remark2rehype)
+    .use(rehypeKatex, {
+      errorColor: 'orange',
+      macros: macros
+    })
+    .use(stringify)
+
+  const targetText = '$\\RR$'
+
+  const result = processor.processSync(targetText)
+  const renderedAst = parseHtml(result.toString())
+
+  const expectedInlineMathChildren = parseHtml(katex.renderToString('\\RR', {macros: macros})).children
+
+  expect(renderedAst)
+    .toEqual(u('root', {data: {quirksMode: false}}, [
+      h('p', [
+        h('span', {className: 'inlineMath'}, expectedInlineMathChildren)
+      ])
+    ]))
+})
+
 it('should handle error', () => {
   const processor = remark()
     .use(math)


### PR DESCRIPTION
Allows the following usage:

```
const macros = {
  '\\RR': '\\mathbb{R}
}

const processor = unified()
  .use(remark)
  .use(remarkMath)
  .use(remark2rehype)
  .use(katex, {macros: macros})
  .use(stringify)
```