### PR TITLE
Upgrade Katex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5588,9 +5588,9 @@
       "dev": true
     },
     "katex": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.7.1.tgz",
-      "integrity": "sha1-BrtSmO+tBeHnIoA1uo4VkfMGG48=",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.9.0.tgz",
+      "integrity": "sha512-lp3x90LT1tDZBW2tjLheJ98wmRMRjUHwk4QpaswT9bhqoQZ+XA4cPcjcQBxgOQNwaOSt6ZeL/a6GKQ1of3LFxQ==",
       "dev": true,
       "requires": {
         "match-at": "0.1.1"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "github-markdown-css": "^2.6.0",
     "hastscript": "^3.0.1",
     "jest": "^20.0.4",
-    "katex": "^0.7.1",
+    "katex": "^0.9.0",
     "lerna": "^2.0.0-rc.5",
     "rehype-parse": "^4.0.0",
     "rehype-stringify": "^3.0.0",

--- a/packages/rehype-katex/package.json
+++ b/packages/rehype-katex/package.json
@@ -25,7 +25,7 @@
     "remark-math": ">=1.0.0"
   },
   "dependencies": {
-    "katex": "^0.7.1",
+    "katex": "^0.9.0",
     "rehype-parse": "^3.0.0",
     "unified": "^6.1.1",
     "unist-util-position": "^3.0.0",

--- a/packages/remark-html-katex/package.json
+++ b/packages/remark-html-katex/package.json
@@ -25,7 +25,7 @@
     "remark-math": ">=1.0.0"
   },
   "dependencies": {
-    "katex": "^0.7.1",
+    "katex": "^0.9.0",
     "rehype-parse": "^3.0.0",
     "unified": "^6.1.1",
     "unist-util-position": "^3.0.0",

--- a/specs/rehype-katex.spec.js
+++ b/specs/rehype-katex.spec.js
@@ -164,7 +164,7 @@ it('should handle error even fallback rendering failed', () => {
     })
     .use(stringify)
 
-  const targetText = '$ê$'
+  const targetText = '$ê&$'
 
   const result = processor.processSync(targetText)
   const renderedAst = parseHtml(result.toString())
@@ -173,7 +173,7 @@ it('should handle error even fallback rendering failed', () => {
     .toEqual(u('root', {data: {quirksMode: false}}, [
       h('p', [
         h('span', {className: 'inlineMath'}, [
-          h('code', {className: 'katex', style: 'color: orange'}, 'ê')
+          h('code', {className: 'katex', style: 'color: orange'}, 'ê&')
         ])
       ])
     ]))

--- a/specs/remark-html-katex.spec.js
+++ b/specs/remark-html-katex.spec.js
@@ -86,7 +86,7 @@ it('should handle error even fallback rendering failed', () => {
     })
     .use(html)
 
-  const targetText = '$ê$'
+  const targetText = '$ê&$'
 
   const result = processor.processSync(targetText)
   const renderedAst = parseHtml(result.toString())
@@ -95,7 +95,7 @@ it('should handle error even fallback rendering failed', () => {
     .toEqual(u('root', {data: {quirksMode: false}}, [
       h('p', [
         h('span', {className: 'inlineMath'}, [
-          h('code', {className: 'katex', style: 'color: orange'}, 'ê')
+          h('code', {className: 'katex', style: 'color: orange'}, 'ê&')
         ])
       ]),
       u('text', '\n')


### PR DESCRIPTION
Upgrades to Katex 0.9.0

`ê` works in Katex now so I put in a parse error for that test.