### PR TITLE
Bump peer deps version range of remark-parse

### DIFF
--- a/packages/remark-math/package.json
+++ b/packages/remark-math/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/Rokt33r/remark-math#readme",
   "peerDependencies": {
-    "remark-parse": "^3.0.0 || ^4.0.0 || ^5.0.0"
+    "remark-parse": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "dependencies": {
     "trim-trailing-lines": "^1.1.0"


### PR DESCRIPTION
There doesn't seem to be breaking changes [from v5 to v6](https://github.com/remarkjs/remark/releases/tag/remark-parse%406.0.0) for peer dependency `remark-parse`.